### PR TITLE
ECFP Code Quality Improvements Closes #51

### DIFF
--- a/src/algorithms/ecfp.jl
+++ b/src/algorithms/ecfp.jl
@@ -1,3 +1,4 @@
+# Please note: This docstring was revised for spelling, formatting, and coherence with the implementation using Claude Code
 """
     ECFP{N}(radius)
 
@@ -26,12 +27,6 @@ ECFP{512, Int64}(2)
 julia> ECFP{2048}(Int8(3))
 ECFP{2048, Int8}(3)
 ```
-
-# References
-Rogers, D., & Hahn, M. (2010). Extended-connectivity fingerprints.
-Journal of Chemical Information and Modeling, 50(5), 742-754.
-
-<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 struct ECFP{N, R<:Integer} <: AbstractFingerprint
     radius::R
@@ -49,6 +44,7 @@ ECFP(radius::R) where {R<:Integer} = ECFP{1024, R}(radius)
 ECFP{N}() where N = ECFP{N, Int}(2)
 ECFP() = ECFP{1024, Int}(2)
 
+# Please note: This docstring was revised for spelling, formatting, and coherence with the implementation using Claude Code
 """
     ecfp_hash_combine(seed::UInt32, value::UInt32)
 
@@ -68,10 +64,10 @@ which is based on the boost C++ library's hash_combine function.
 ```jldoctest
 julia> using MolecularFingerprints
 
-julia> ecfp_hash_combine(UInt32(0), UInt32(42))
+julia> MolecularFingerprints.ecfp_hash_combine(UInt32(0), UInt32(42))
 0x9e3779e3
 
-julia> result = ecfp_hash_combine(UInt32(100), UInt32(200));
+julia> result = MolecularFingerprints.ecfp_hash_combine(UInt32(100), UInt32(200));
 
 julia> result isa UInt32
 true
@@ -79,13 +75,12 @@ true
 
 # References
 Boost hash implementation, as provided by RDKit: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/RDGeneral/hash/hash.hpp
-
-<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 function ecfp_hash_combine(seed::UInt32, value::UInt32)
     return seed ⊻ (value + UInt32(0x9e3779b9) + (seed << 6) + (seed >> 2))
 end
 
+# Please note: This docstring was revised for spelling, formatting, and coherence with the implementation using Claude Code
 """
     ecfp_hash(v::AbstractVector{UInt32})
 
@@ -104,13 +99,13 @@ to produce a single hash value representing the entire vector.
 ```jldoctest
 julia> using MolecularFingerprints
 
-julia> ecfp_hash(UInt32[1, 2, 3])
-0xa8c41606
+julia> MolecularFingerprints.ecfp_hash(UInt32[1, 2, 3])
+0xfb58d153
 
-julia> ecfp_hash(UInt32[])
+julia> MolecularFingerprints.ecfp_hash(UInt32[])
 0x00000000
 
-julia> result = ecfp_hash(UInt32[42, 100, 200]);
+julia> result = MolecularFingerprints.ecfp_hash(UInt32[42, 100, 200]);
 
 julia> result isa UInt32
 true
@@ -118,8 +113,6 @@ true
 
 # References
 Boost hash implementation, as provided by RDKit: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/RDGeneral/hash/hash.hpp
-
-<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 function ecfp_hash(v::AbstractVector{UInt32})
     seed = UInt32(0)
@@ -129,6 +122,7 @@ function ecfp_hash(v::AbstractVector{UInt32})
     return seed
 end
 
+# Please note: This docstring was revised for spelling, formatting, and coherence with the implementation using Claude Code
 """
     MorganAtomEnv(;
         code::UInt32,
@@ -145,8 +139,6 @@ encountered during ECFP fingerprint generation.
 - `code::UInt32`: Hash code representing the atomic environment
 - `atom_id::Int`: Identifier of the central atom
 - `layer::Int`: Radius/layer at which this environment was computed
-
-<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 struct MorganAtomEnv
     code::UInt32
@@ -156,6 +148,7 @@ struct MorganAtomEnv
     MorganAtomEnv(code::UInt32, atom_id::Int, layer::Int) = new(code, atom_id, layer)
 end
 
+# Please note: This docstring was revised for spelling, formatting, and coherence with the implementation using Claude Code
 """
     AccumTuple(;
         bits::BitVector,
@@ -172,8 +165,6 @@ by storing bond connectivity patterns along with invariant hashes.
 - `bits::BitVector`: Bit representation of the bond neighborhood
 - `invariant::UInt32`: Hash invariant for this neighborhood
 - `atom_index::Int`: Index of the central atom
-
-<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 struct AccumTuple
     bits::BitVector
@@ -197,6 +188,7 @@ function Base.isless(a::AccumTuple, b::AccumTuple)
     return a.atom_index < b.atom_index
 end
 
+# Please note: This docstring was revised for spelling, formatting, and coherence with the implementation using Claude Code
 """
     rdkit_bond_type(bond::SMILESBond)
 
@@ -216,8 +208,6 @@ we currently only support the most common bond types (1 to 6).
 
 # References
 RDKit bond types: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/GraphMol/Bond.h#L55
-
-<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 function rdkit_bond_type(bond::SMILESBond)
     if !bond.isaromatic && bond.order in 1:6
@@ -238,6 +228,7 @@ function rdkit_bond_type(bond::SMILESBond)
     # end
 end
 
+# Please note: This docstring was revised for spelling, formatting, and coherence with the implementation using Claude Code
 """
     get_bond_invariants(mol::MolGraph)
 
@@ -257,13 +248,12 @@ provided by [MolecularGraph.jl](https://github.com/mojaie/MolecularGraph.jl), a 
 
 # References
 RDKit implementation: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/GraphMol/Fingerprints/MorganGenerator.cpp#L126
-
-<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 function get_bond_invariants(mol::AbstractMolGraph)
     return [UInt32(rdkit_bond_type(bond)) for (_, bond) in mol.eprops]
 end
 
+# Please note: This docstring was revised for spelling, formatting, and coherence with the implementation using Claude Code
 """
     get_atom_invariants(smiles::AbstractString)
     get_atom_invariants(mol::AbstractMolGraph)
@@ -293,7 +283,7 @@ The computed invariants include (in order):
 ```jldoctest
 julia> using MolecularFingerprints, MolecularGraph
 
-julia> invariants = get_atom_invariants("CCO");
+julia> invariants = MolecularFingerprints.get_atom_invariants("CCO");
 
 julia> length(invariants)  # 3 atoms: C, C, O
 3
@@ -304,8 +294,6 @@ true
 
 # References
 RDKit implementation: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/GraphMol/Fingerprints/FingerprintUtil.cpp#L244
-
-<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 get_atom_invariants(smiles::AbstractString) = get_atom_invariants(smilestomol(smiles))
 
@@ -363,6 +351,7 @@ function get_atom_invariants(mol::AbstractMolGraph)
     return invariants
 end
 
+# Please note: This docstring was revised for spelling, formatting, and coherence with the implementation using Claude Code
 """
     fingerprint(mol::MolGraph, calc::ECFP{N}) where N
 
@@ -408,8 +397,6 @@ true
 # References
 - Rogers, D., & Hahn, M. (2010). Extended-connectivity fingerprints. J. Chem. Inf. Model., 50(5), 742-754.
 - RDKit implementation: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/GraphMol/Fingerprints/MorganGenerator.cpp#L257
-
-<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 function fingerprint(mol::MolGraph, calc::ECFP{N}) where N
     num_atoms = nv(mol)

--- a/src/algorithms/ecfp.jl
+++ b/src/algorithms/ecfp.jl
@@ -30,6 +30,8 @@ ECFP{2048, Int8}(3)
 # References
 Rogers, D., & Hahn, M. (2010). Extended-connectivity fingerprints.
 Journal of Chemical Information and Modeling, 50(5), 742-754.
+
+<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 struct ECFP{N, R<:Integer} <: AbstractFingerprint
     radius::R
@@ -62,8 +64,23 @@ which is based on the boost C++ library's hash_combine function.
 # Returns
 - `UInt32`: Combined hash value
 
+# Examples
+```jldoctest
+julia> using MolecularFingerprints
+
+julia> ecfp_hash_combine(UInt32(0), UInt32(42))
+0x9e3779e3
+
+julia> result = ecfp_hash_combine(UInt32(100), UInt32(200));
+
+julia> result isa UInt32
+true
+```
+
 # References
 Boost hash implementation, as provided by RDKit: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/RDGeneral/hash/hash.hpp
+
+<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 function ecfp_hash_combine(seed::UInt32, value::UInt32)
     return seed ⊻ (value + UInt32(0x9e3779b9) + (seed << 6) + (seed >> 2))
@@ -83,8 +100,26 @@ to produce a single hash value representing the entire vector.
 # Returns
 - `UInt32`: Hash value representing the input vector
 
+# Examples
+```jldoctest
+julia> using MolecularFingerprints
+
+julia> ecfp_hash(UInt32[1, 2, 3])
+0xa8c41606
+
+julia> ecfp_hash(UInt32[])
+0x00000000
+
+julia> result = ecfp_hash(UInt32[42, 100, 200]);
+
+julia> result isa UInt32
+true
+```
+
 # References
 Boost hash implementation, as provided by RDKit: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/RDGeneral/hash/hash.hpp
+
+<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 function ecfp_hash(v::AbstractVector{UInt32})
     seed = UInt32(0)
@@ -110,6 +145,8 @@ encountered during ECFP fingerprint generation.
 - `code::UInt32`: Hash code representing the atomic environment
 - `atom_id::Int`: Identifier of the central atom
 - `layer::Int`: Radius/layer at which this environment was computed
+
+<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 struct MorganAtomEnv
     code::UInt32
@@ -135,6 +172,8 @@ by storing bond connectivity patterns along with invariant hashes.
 - `bits::BitVector`: Bit representation of the bond neighborhood
 - `invariant::UInt32`: Hash invariant for this neighborhood
 - `atom_index::Int`: Index of the central atom
+
+<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 struct AccumTuple
     bits::BitVector
@@ -177,6 +216,8 @@ we currently only support the most common bond types (1 to 6).
 
 # References
 RDKit bond types: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/GraphMol/Bond.h#L55
+
+<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 function rdkit_bond_type(bond::SMILESBond)
     if !bond.isaromatic && bond.order in 1:6
@@ -216,6 +257,8 @@ provided by [MolecularGraph.jl](https://github.com/mojaie/MolecularGraph.jl), a 
 
 # References
 RDKit implementation: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/GraphMol/Fingerprints/MorganGenerator.cpp#L126
+
+<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 function get_bond_invariants(mol::AbstractMolGraph)
     return [UInt32(rdkit_bond_type(bond)) for (_, bond) in mol.eprops]
@@ -233,11 +276,9 @@ based on the Daylight atomic invariants. This implementation follows the RDKit a
 # Arguments
 - `smiles::AbstractString`: SMILES string representation of a molecule
 - `mol::AbstractMolGraph`: Molecular graph structure
-- `atom_index`: Index of the specific atom to compute invariants for. If not specified, invariants for all atoms are computed and returned
 
 # Returns
-- For single atom: `Vector{UInt32}` containing the invariant components
-- For all atoms: `Vector{Vector{UInt32}}` with invariants for each atom
+- `Vector{UInt32}`: Hash invariants for each atom in the molecule
 
 # Invariant Components
 The computed invariants include (in order):
@@ -248,8 +289,23 @@ The computed invariants include (in order):
 5. Delta mass (difference from standard isotope mass)
 6. Ring membership indicator (1 if atom is in a ring, omitted otherwise)
 
+# Examples
+```jldoctest
+julia> using MolecularFingerprints, MolecularGraph
+
+julia> invariants = get_atom_invariants("CCO");
+
+julia> length(invariants)  # 3 atoms: C, C, O
+3
+
+julia> all(x -> x isa UInt32, invariants)
+true
+```
+
 # References
 RDKit implementation: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/GraphMol/Fingerprints/FingerprintUtil.cpp#L244
+
+<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 get_atom_invariants(smiles::AbstractString) = get_atom_invariants(smilestomol(smiles))
 
@@ -333,15 +389,27 @@ expanding atomic neighborhoods up to the specified radius.
 - `BitVector`: Binary fingerprint of length N with bits set for detected molecular features
 
 # Examples
-```julia
-mol = smilestomol("CCO")  # Ethanol
-fp_calc = ECFP{2048}(2)   # ECFP4 with 2048 bits
-fp = fingerprint(mol, fp_calc)
+```jldoctest
+julia> using MolecularFingerprints, MolecularGraph
+
+julia> mol = smilestomol("CCO");  # Ethanol
+
+julia> fp_calc = ECFP{2048}(2);   # ECFP4 with 2048 bits
+
+julia> fp = fingerprint(mol, fp_calc);
+
+julia> length(fp)
+2048
+
+julia> fp isa BitVector
+true
 ```
 
 # References
 - Rogers, D., & Hahn, M. (2010). Extended-connectivity fingerprints. J. Chem. Inf. Model., 50(5), 742-754.
 - RDKit implementation: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/GraphMol/Fingerprints/MorganGenerator.cpp#L257
+
+<!-- Please note: This docstring was revised for spelling, formatting, and coherence using Claude Code (https://claude.com/product/claude-code). -->
 """
 function fingerprint(mol::MolGraph, calc::ECFP{N}) where N
     num_atoms = nv(mol)

--- a/src/algorithms/ecfp.jl
+++ b/src/algorithms/ecfp.jl
@@ -1,5 +1,5 @@
 """
-    ECFP{N}(radius::Int = 2)
+    ECFP{N}(radius)
 
 Extended-Connectivity Fingerprint (ECFP) calculator.
 
@@ -7,118 +7,45 @@ ECFPs are circular fingerprints encoding a local molecular environment around ea
 up to a specified radius. This implementation closely follows the RDKit algorithm.
 
 # Fields
-- `radius::Int`: The maximum number of bonds to traverse from each atom (default: 2)
+- `radius::R`: The maximum number of bonds to traverse from each atom (default: 2)
 
 # Type Parameters
 - `N`: The size of the fingerprint bit vector
 
 # Examples
-```julia
-# Create ECFP4 (radius=2) with 2048 bits
-fp_calc = ECFP{2048}(2)
+```jldoctest
+julia> ECFP()
+ECFP{1024, Int64}(2)
 
-# Create ECFP6 (radius=3) with 1024 bits
-fp_calc = ECFP{1024}(3)
+julia> ECFP(3)
+ECFP{1024, Int64}(3)
+
+julia> ECFP{512}()
+ECFP{512, Int64}(2)
+
+julia> ECFP{2048}(Int8(3))
+ECFP{2048, Int8}(3)
 ```
 
 # References
 Rogers, D., & Hahn, M. (2010). Extended-connectivity fingerprints.
 Journal of Chemical Information and Modeling, 50(5), 742-754.
 """
-struct ECFP{N} <: AbstractFingerprint
-    radius::Int
+struct ECFP{N, R<:Integer} <: AbstractFingerprint
+    radius::R
 
-    function ECFP{N}(radius::Int = 2) where N
+    function ECFP{N, R}(radius) where {N, R<:Integer}
         radius >= 0 || throw(DomainError(radius, "radius must be non-negative"))
         N > 0 || throw(DomainError(N, "fingerprint size N must be positive"))
-        return new{N}(radius)
+        return new{N, R}(radius)
     end
 end
 
-function ECFP(radius::Int = 2)
-    return ECFP{1024}(radius)
-end
+ECFP{N}(radius::R) where {N, R<:Integer} = ECFP{N, R}(radius)
+ECFP(radius::R) where {R<:Integer} = ECFP{1024, R}(radius)
 
-"""
-    ecfp_atom_invariant(smiles::AbstractString)
-    ecfp_atom_invariant(mol::AbstractMolGraph)
-    ecfp_atom_invariant(mol::AbstractMolGraph, atom_index)
-
-Calculate atomic invariants for ECFP fingerprint generation.
-
-The atomic invariants are properties of an atom that don't depend on initial atom numbering,
-based on the Daylight atomic invariants. This implementation follows the RDKit approach.
-
-# Arguments
-- `smiles::AbstractString`: SMILES string representation of a molecule
-- `mol::AbstractMolGraph`: Molecular graph structure
-- `atom_index`: Index of the specific atom to compute invariants for. If not specified, invariants for all atoms are computed and returned
-
-# Returns
-- For single atom: `Vector{UInt32}` containing the invariant components
-- For all atoms: `Vector{Vector{UInt32}}` with invariants for each atom
-
-# Invariant Components
-The computed invariants include (in order):
-1. Atomic number
-2. Total degree (number of neighbors including implicit hydrogens)
-3. Total number of hydrogens (implicit + explicit)
-4. Atomic charge
-5. Delta mass (difference from standard isotope mass)
-6. Ring membership indicator (1 if atom is in a ring, omitted otherwise)
-
-# References
-RDKit implementation: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/GraphMol/Fingerprints/FingerprintUtil.cpp#L244
-"""
-ecfp_atom_invariant(smiles::AbstractString) = ecfp_atom_invariant(smilestomol(smiles))
-
-ecfp_atom_invariant(mol::AbstractMolGraph) = [ecfp_atom_invariant(mol, i) for i in 1:nv(mol)]
-
-function ecfp_atom_invariant(mol::AbstractMolGraph, atom_index)
-    atom = mol.vprops[atom_index]
-
-    # Get number of implicit and explicit hydrogens
-    implicit_hs = implicit_hydrogens(mol)[atom_index]
-    explicit_hs = explicit_hydrogens(mol)[atom_index]
-    total_hs = implicit_hs + explicit_hs
-
-    # Get number of neighbor atoms (including the implicit hydrogens)
-    total_degree = degree(mol.graph, atom_index) + implicit_hs
-
-    # Get valence
-    valence_info = valence(mol)
-    v = valence_info[atom_index]
-
-    # Get atomic number
-    at_number = atom_number(atom)
-
-    # Get difference from atomic mass to average standard weight
-    atom_mass = exact_mass(atom)
-    standard_mass = monoiso_mass(atom)
-    delta_mass = trunc(Int, atom_mass - standard_mass)
-
-    # Get formal charge
-    at_charge = atom_charge(atom)
-
-    # Check if atom is in a ring
-    ring_info = is_in_ring(mol)
-    in_ring = ring_info[atom_index]
-
-    # Return all invariants as an UInt32 Vector. Add an extra component if we are in a ring.
-    components = UInt32[
-        at_number, # atomic number
-        total_degree, # number of neighbors (including implicit hydrogens)
-        total_hs, # total number of hydrogens
-        at_charge, # atomic charge
-        delta_mass, # difference between atom and standard mass
-    ]
-
-    if in_ring
-        push!(components, UInt32(1))
-    end
-
-    return components
-end
+ECFP{N}() where N = ECFP{N, Int}(2)
+ECFP() = ECFP{1024, Int}(2)
 
 """
     ecfp_hash_combine(seed::UInt32, value::UInt32)
@@ -143,7 +70,7 @@ function ecfp_hash_combine(seed::UInt32, value::UInt32)
 end
 
 """
-    ecfp_hash(v::Vector{UInt32})
+    ecfp_hash(v::AbstractVector{UInt32})
 
 Generate a hash value from a vector of UInt32 values.
 
@@ -151,7 +78,7 @@ Iteratively combines all values in the vector using the ECFP hash combining algo
 to produce a single hash value representing the entire vector.
 
 # Arguments
-- `v::Vector{UInt32}`: Vector of values to hash
+- `v::AbstractVector{UInt32}`: Vector of values to hash
 
 # Returns
 - `UInt32`: Hash value representing the input vector
@@ -159,7 +86,7 @@ to produce a single hash value representing the entire vector.
 # References
 Boost hash implementation, as provided by RDKit: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/RDGeneral/hash/hash.hpp
 """
-function ecfp_hash(v::Vector{UInt32})
+function ecfp_hash(v::AbstractVector{UInt32})
     seed = UInt32(0)
     for value in v
         seed = ecfp_hash_combine(seed, value)
@@ -219,32 +146,16 @@ end
 
 
 function Base.isless(a::AccumTuple, b::AccumTuple)
+    # Length inequality should not occur in our case, but let's put it here for completeness
+    length(a.bits) != length(b.bits) && return length(a.bits) < length(b.bits)
+
     # Compare ra and rb in reverse order, because this is how boost::dynamic_bitset does it
-    for (abit, bbit) in zip(Iterators.reverse(a.bits), Iterators.reverse(b.bits))
+    for (abit, bbit) in Iterators.reverse(zip(a.bits, b.bits))
         abit != bbit && return abit < bbit
     end
-    length(a.bits) != length(b.bits) && return length(a.bits) < length(b.bits) # Should not occur in our case, but let's put it here for completeness
 
     a.invariant != b.invariant && return a.invariant < b.invariant
-    a.atom_index < b.atom_index
-end
-
-"""
-    get_atom_invariants(mol::MolGraph)
-
-Compute hashed atom invariants for all atoms in a molecule.
-
-# Arguments
-- `mol::MolGraph`: Input molecular graph
-
-# Returns
-- `Vector{UInt32}`: Hashed invariant values for each atom
-
-# References
-RDKit implementation: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/GraphMol/Fingerprints/MorganGenerator.cpp#L42
-"""
-function get_atom_invariants(mol::MolGraph)
-    return [ecfp_hash(x) for x in ecfp_atom_invariant(mol)]
+    return a.atom_index < b.atom_index
 end
 
 """
@@ -274,7 +185,7 @@ function rdkit_bond_type(bond::SMILESBond)
         error("Unsupported bond type")
     end
 
-    # This is not well tested on out of scope for this project
+    # This is not well tested and out of scope for this project
     # if bond.isaromatic
     #     return 12 # AROMATIC
     # elseif bond.order == 0
@@ -306,8 +217,94 @@ provided by [MolecularGraph.jl](https://github.com/mojaie/MolecularGraph.jl), a 
 # References
 RDKit implementation: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/GraphMol/Fingerprints/MorganGenerator.cpp#L126
 """
-function get_bond_invariants(mol::MolGraph)
+function get_bond_invariants(mol::AbstractMolGraph)
     return [UInt32(rdkit_bond_type(bond)) for (_, bond) in mol.eprops]
+end
+
+"""
+    get_atom_invariants(smiles::AbstractString)
+    get_atom_invariants(mol::AbstractMolGraph)
+
+Calculate atomic invariants for ECFP fingerprint generation.
+
+The atomic invariants are properties of an atom that don't depend on initial atom numbering,
+based on the Daylight atomic invariants. This implementation follows the RDKit approach.
+
+# Arguments
+- `smiles::AbstractString`: SMILES string representation of a molecule
+- `mol::AbstractMolGraph`: Molecular graph structure
+- `atom_index`: Index of the specific atom to compute invariants for. If not specified, invariants for all atoms are computed and returned
+
+# Returns
+- For single atom: `Vector{UInt32}` containing the invariant components
+- For all atoms: `Vector{Vector{UInt32}}` with invariants for each atom
+
+# Invariant Components
+The computed invariants include (in order):
+1. Atomic number
+2. Total degree (number of neighbors including implicit hydrogens)
+3. Total number of hydrogens (implicit + explicit)
+4. Atomic charge
+5. Delta mass (difference from standard isotope mass)
+6. Ring membership indicator (1 if atom is in a ring, omitted otherwise)
+
+# References
+RDKit implementation: https://github.com/rdkit/rdkit/blob/Release_2025_09_4/Code/GraphMol/Fingerprints/FingerprintUtil.cpp#L244
+"""
+get_atom_invariants(smiles::AbstractString) = get_atom_invariants(smilestomol(smiles))
+
+function get_atom_invariants(mol::AbstractMolGraph)
+    num_atoms = nv(mol.graph)
+    num_atoms == 0 && return UInt32[]
+
+    # Get molecule information for all atoms at once
+    all_implicit_hs = implicit_hydrogens(mol)
+    all_explicit_hs = explicit_hydrogens(mol)
+    ring_membership = is_in_ring(mol)
+
+    # Pre-allocate output and components
+    invariants = Vector{UInt32}(undef, num_atoms)
+    components = Vector{UInt32}(undef, 6)
+
+    @inbounds for i in 1:num_atoms
+        atom = mol.vprops[i]
+
+        # Get number of implicit and explicit hydrogens
+        implicit_hs = all_implicit_hs[i]
+        explicit_hs = all_explicit_hs[i]
+        total_hs = implicit_hs + explicit_hs
+
+        # Get number of neighbor atoms (including the implicit hydrogens)
+        total_degree = degree(mol.graph, i) + implicit_hs
+
+        # Get atomic number
+        at_number = atom_number(atom)
+
+        # Get difference from atomic mass to average standard weight
+        atom_mass = exact_mass(atom)::Float64
+        standard_mass = monoiso_mass(atom)::Float64
+        delta_mass = atom_mass - standard_mass
+
+        # Get formal charge
+        at_charge = atom_charge(atom)
+
+        # Build all components
+        components[1] = UInt32(at_number)
+        components[2] = UInt32(total_degree)
+        components[3] = UInt32(total_hs)
+        components[4] = UInt32(at_charge)
+        components[5] = unsafe_trunc(UInt32, delta_mass)
+
+        # Hash with or without the ring component
+        if ring_membership[i]
+            components[6] = UInt32(1)
+            invariants[i] = ecfp_hash(@view components[1:6])
+        else
+            invariants[i] = ecfp_hash(@view components[1:5])
+        end
+    end
+
+    return invariants
 end
 
 """
@@ -348,23 +345,29 @@ fp = fingerprint(mol, fp_calc)
 """
 function fingerprint(mol::MolGraph, calc::ECFP{N}) where N
     num_atoms = nv(mol)
+    num_atoms == 0 && return falses(N)
+
     num_bonds = ne(mol)
     ernk = edge_rank(mol)
 
     # Generate atom hashes
-    atom_invariants::Vector{UInt32} = get_atom_invariants(mol)
-    bond_invariants::Vector{UInt32} = get_bond_invariants(mol)
+    atom_invariants = get_atom_invariants(mol)
+    bond_invariants = get_bond_invariants(mol)
 
-    result::Vector{MorganAtomEnv} = []
+    result = Vector{MorganAtomEnv}(undef, 0)
+    sizehint!(result, num_atoms * (calc.radius + 1))
 
-    current_invariants::Vector{UInt32} = copy(atom_invariants)
-    next_layer_invariants::Vector{UInt32} = zeros(num_atoms)
+    current_invariants = copy(atom_invariants)
+    next_layer_invariants = zeros(UInt32, num_atoms)
 
-    neighborhood_invariants::Vector{Pair{UInt32, UInt32}} = []
+    neighborhood_invariants = Vector{Pair{UInt32, UInt32}}(undef, 0)
+    sizehint!(neighborhood_invariants, 6) # Assume ~6 neighbors per atom
 
-    neighborhoods::Set{BitVector} = Set()
-    atom_neighborhoods::Vector{BitVector} = [falses(num_bonds) for _ in 1:num_atoms]
-    round_atom_neighborhoods::Vector{BitVector} = [falses(num_bonds) for _ in 1:num_atoms]
+    neighborhoods = Set{BitVector}()
+    sizehint!(neighborhoods, num_atoms * (calc.radius + 1))
+
+    atom_neighborhoods = [falses(num_bonds) for _ in 1:num_atoms]
+    round_atom_neighborhoods = [falses(num_bonds) for _ in 1:num_atoms]
 
     # These atoms are skipped
     dead_atoms = falses(num_atoms)
@@ -374,15 +377,16 @@ function fingerprint(mol::MolGraph, calc::ECFP{N}) where N
         push!(result, MorganAtomEnv(hash, i, 0)) # Note: atom id should start at 0
     end
 
+    all_neighborhoods_this_round = Vector{AccumTuple}(undef, 0)
+    sizehint!(all_neighborhoods_this_round, num_atoms)
+
     # Do subsequent rounds
     for layer in 1:calc.radius
-        all_neighborhoods_this_round::Vector{AccumTuple} = []
+        empty!(all_neighborhoods_this_round)
 
         for atom_index in 1:num_atoms
             # If the atom is marked as dead, skip
-            if dead_atoms[atom_index]
-                continue
-            end
+            dead_atoms[atom_index] && continue
 
             # If the atom has no neighbors, also skip
             neighbor_indices = mol.graph.fadjlist[atom_index]
@@ -394,7 +398,7 @@ function fingerprint(mol::MolGraph, calc::ECFP{N}) where N
             # Add up-to-date variants of neighbors
             empty!(neighborhood_invariants)
 
-            for neighbor_index in neighbor_indices
+            @inbounds for neighbor_index in neighbor_indices
                 bond_index = edge_rank(ernk, atom_index, neighbor_index)
                 round_atom_neighborhoods[atom_index][bond_index] = true;
 
@@ -409,10 +413,10 @@ function fingerprint(mol::MolGraph, calc::ECFP{N}) where N
             sort!(neighborhood_invariants)
 
             # Calculate the new atom invariant by combining the neighbors'
-            invar::UInt32 = layer - 1
+            invar = UInt32(layer - 1)
             invar = ecfp_hash_combine(invar, current_invariants[atom_index])
 
-            for (bond_invar, neighbor_invar) in neighborhood_invariants
+            @inbounds for (bond_invar, neighbor_invar) in neighborhood_invariants
                 # hash the pair separately first, then combine with the total invariant (this is how rdkit does it)
                 nb_invar = ecfp_hash([bond_invar, neighbor_invar])
                 invar = ecfp_hash_combine(invar, nb_invar)
@@ -445,23 +449,22 @@ function fingerprint(mol::MolGraph, calc::ECFP{N}) where N
             end
         end
 
-        # Swap current and next layer invariant vectors
-        current_invariants = copy(next_layer_invariants)
-        next_layer_invariants = zeros(num_atoms)
+        # Use next_layer_invariants as the new current_invariants by swapping both vector references
+        current_invariants, next_layer_invariants = next_layer_invariants, current_invariants
 
-        # Start with this round's neighbors on the next rounds
-        atom_neighborhoods = round_atom_neighborhoods
+        # Start with this round's neighbors on the next round
+        atom_neighborhoods, round_atom_neighborhoods = round_atom_neighborhoods, atom_neighborhoods
+
+        # Reset round neighborhoods for next iteration
+        for bv in round_atom_neighborhoods
+            fill!(bv, false)
+        end
     end
 
-    fp::BitVector = falses(N)
+    fp = falses(N)
 
-    for env in result
-        seed::UInt32 = env.code
-
-        bit_id = seed
-        if N != 0
-            bit_id = mod(bit_id, N)
-        end
+    @inbounds for env in result
+        bit_id = env.code % N
 
         # We could also use an integer vector for the fingerprint here, in that case we would
         # add one and get a count instead of just a bit map (rdkit provides a configuration option for this)
@@ -471,4 +474,3 @@ function fingerprint(mol::MolGraph, calc::ECFP{N}) where N
 
     return fp
 end
-

--- a/test/unit/algorithms/ecfp_tests.jl
+++ b/test/unit/algorithms/ecfp_tests.jl
@@ -58,6 +58,16 @@ bitset_to_string(bitset) = join(Int.(bitset), "")
         ecfp0 = ECFP{512}(0)
         @test ecfp0.radius == 0
 
+        # Test default size
+        ecfp_default_size = ECFP(3)
+        @test ecfp_default_size isa ECFP{1024}
+        @test ecfp_default_size.radius == 3
+
+        # Test default radius
+        ecfp_default_radius = ECFP{512}()
+        @test ecfp_default_radius isa ECFP{512}
+        @test ecfp_default_radius.radius == 2
+
          # Test invalid radius
         @test_throws DomainError ECFP{1024}(-1)
 


### PR DESCRIPTION
This PR provides the following changes to the ECFP algorithm and its unit test:

# Interface and Algorithm
- Changed the ECFP radius to a generic Integer type
- Changed implementation of `get_atom_invariants` to work on a whole molecule at once, improving performance with the `MolecularGraph.jl` API
- Removed type annotations whereever possible (the hashing methods are still limited to `UInt32`, because we are replicating the exact behaviour of RDKit, which is only defined for `UInt32`s. The same applies for the internally used structs)
- Added pre-allocation to vectors in the main algorithm, removed unnecessary (re-)allocations

# Docstrings
- Updated docstrings to match changed function signatures
- Added jldoctests throughout the documentation
- Marked LLM usage

The unit test `ecfp_tests.jl` has be updated accordingly.